### PR TITLE
Refactor tests

### DIFF
--- a/tests/ConsumerHandler/ConsumerHandlerTest.php
+++ b/tests/ConsumerHandler/ConsumerHandlerTest.php
@@ -18,7 +18,7 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 	/**
 	 * @return int[][]
 	 */
-	public function resultCodeProvider(): array
+	public function resultCodeDataProvider(): array
 	{
 		return [
 			[ConsumerInterface::MSG_ACK],
@@ -29,7 +29,7 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider resultCodeProvider
+	 * @dataProvider resultCodeDataProvider
 	 *
 	 * @param int $code
 	 */

--- a/tests/ConsumerHandler/ConsumerHandlerTest.php
+++ b/tests/ConsumerHandler/ConsumerHandlerTest.php
@@ -18,7 +18,7 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 	/**
 	 * @return int[][]
 	 */
-	public function resultCodesProvider(): array
+	public function resultCodeProvider(): array
 	{
 		return [
 			[ConsumerInterface::MSG_ACK],
@@ -29,7 +29,7 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * @dataProvider resultCodesProvider
+	 * @dataProvider resultCodeProvider
 	 *
 	 * @param int $code
 	 */

--- a/tests/ConsumerHandler/ConsumerHandlerTest.php
+++ b/tests/ConsumerHandler/ConsumerHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace VasekPurchart\RabbitMqConsumerHandlerBundle\ConsumerHandler;
 
 use Doctrine\ORM\EntityManager;
+use Generator;
 use OldSound\RabbitMqBundle\RabbitMq\ConsumerInterface;
 use OldSound\RabbitMqBundle\RabbitMq\DequeuerInterface;
 use PHPUnit\Framework\Assert;
@@ -16,16 +17,14 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 {
 
 	/**
-	 * @return int[][]
+	 * @return int[][]|\Generator
 	 */
-	public function resultCodeDataProvider(): array
+	public function resultCodeDataProvider(): Generator
 	{
-		return [
-			[ConsumerInterface::MSG_ACK],
-			[ConsumerInterface::MSG_REJECT],
-			[ConsumerInterface::MSG_REJECT_REQUEUE],
-			[ConsumerInterface::MSG_SINGLE_NACK_REQUEUE],
-		];
+		yield [ConsumerInterface::MSG_ACK];
+		yield [ConsumerInterface::MSG_REJECT];
+		yield [ConsumerInterface::MSG_REJECT_REQUEUE];
+		yield [ConsumerInterface::MSG_SINGLE_NACK_REQUEUE];
 	}
 
 	/**

--- a/tests/ConsumerHandler/ConsumerHandlerTest.php
+++ b/tests/ConsumerHandler/ConsumerHandlerTest.php
@@ -7,6 +7,7 @@ namespace VasekPurchart\RabbitMqConsumerHandlerBundle\ConsumerHandler;
 use Doctrine\ORM\EntityManager;
 use OldSound\RabbitMqBundle\RabbitMq\ConsumerInterface;
 use OldSound\RabbitMqBundle\RabbitMq\DequeuerInterface;
+use PHPUnit\Framework\Assert;
 use Psr\Log\LogLevel;
 use Psr\Log\LoggerInterface;
 use VasekPurchart\RabbitMqConsumerHandlerBundle\Sleeper\Sleeper;
@@ -36,7 +37,7 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 	{
 		$consumerHandler = $this->getConsumerHandlerForNoExpectedHandling();
 
-		$this->assertSame($code, $consumerHandler->processMessage(function () use ($code): int {
+		Assert::assertSame($code, $consumerHandler->processMessage(function () use ($code): int {
 			return $code;
 		}));
 	}
@@ -49,31 +50,31 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 
 		$dequeuer = $this->getDequeuerMock();
 		$dequeuer
-			->expects($this->once())
+			->expects(self::once())
 			->method('forceStopConsumer');
 
 		$entityManager = $this->getOpenEntityManagerMock();
 
 		$logger = $this->getLoggerMock();
 		$logger
-			->expects($this->once())
+			->expects(self::once())
 			->method('error')
 			->with(
-				$this->stringContains('Test'),
-				$this->equalTo([
+				Assert::stringContains('Test'),
+				Assert::equalTo([
 					'exception' => $exception,
 				])
 			);
 		$logger
-			->expects($this->once())
+			->expects(self::once())
 			->method('log')
-			->with(LogLevel::WARNING, $this->stringContains('uncaught exception'));
+			->with(LogLevel::WARNING, Assert::stringContains('uncaught exception'));
 
 		$sleeper = $this->getSleeperMock();
 		$sleeper
-			->expects($this->once())
+			->expects(self::once())
 			->method('sleep')
-			->with($this->equalTo($stopConsumerSleepSeconds));
+			->with(Assert::equalTo($stopConsumerSleepSeconds));
 
 		$consumerHandler = new ConsumerHandler(
 			$stopConsumerSleepSeconds,
@@ -84,7 +85,7 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 			$sleeper
 		);
 
-		$this->assertSame(ConsumerInterface::MSG_REJECT_REQUEUE, $consumerHandler->processMessage(
+		Assert::assertSame(ConsumerInterface::MSG_REJECT_REQUEUE, $consumerHandler->processMessage(
 			function () use ($exception): void {
 				throw $exception;
 			}
@@ -97,7 +98,7 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 
 		$consumerHandler->processMessage(
 			function ($consumerHandler): int {
-				$this->assertInstanceOf(ConsumerHandler::class, $consumerHandler);
+				Assert::assertInstanceOf(ConsumerHandler::class, $consumerHandler);
 
 				return ConsumerInterface::MSG_ACK;
 			}
@@ -110,26 +111,26 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 
 		$dequeuer = $this->getDequeuerMock();
 		$dequeuer
-			->expects($this->once())
+			->expects(self::once())
 			->method('forceStopConsumer');
 
 		$logger = $this->getLoggerMock();
 		$logger
-			->expects($this->once())
+			->expects(self::once())
 			->method('log')
-			->with(LogLevel::WARNING, $this->stringContains('EntityManager was closed'));
+			->with(LogLevel::WARNING, Assert::stringContains('EntityManager was closed'));
 
 		$entityManager = $this->getEntityManagerMock();
 		$entityManager
-			->expects($this->any())
+			->expects(self::any())
 			->method('isOpen')
-			->will($this->returnValue(false));
+			->will(self::returnValue(false));
 
 		$sleeper = $this->getSleeperMock();
 		$sleeper
-			->expects($this->once())
+			->expects(self::once())
 			->method('sleep')
-			->with($this->equalTo($stopConsumerSleepSeconds));
+			->with(Assert::equalTo($stopConsumerSleepSeconds));
 
 		$consumerHandler = new ConsumerHandler(
 			$stopConsumerSleepSeconds,
@@ -151,29 +152,29 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 
 		$dequeuer = $this->getDequeuerMock();
 		$dequeuer
-			->expects($this->once())
+			->expects(self::once())
 			->method('forceStopConsumer');
 
 		$logger = $this->getLoggerMock();
 		$logger
-			->expects($this->once())
+			->expects(self::once())
 			->method('log')
-			->with(LogLevel::WARNING, $this->stringContains('uncaught exception'));
+			->with(LogLevel::WARNING, Assert::stringContains('uncaught exception'));
 		$logger
-			->expects($this->any())
+			->expects(self::any())
 			->method('error');
 
 		$entityManager = $this->getEntityManagerMock();
 		$entityManager
-			->expects($this->any())
+			->expects(self::any())
 			->method('isOpen')
-			->will($this->returnValue(false));
+			->will(self::returnValue(false));
 
 		$sleeper = $this->getSleeperMock();
 		$sleeper
-			->expects($this->once())
+			->expects(self::once())
 			->method('sleep')
-			->with($this->equalTo($stopConsumerSleepSeconds));
+			->with(Assert::equalTo($stopConsumerSleepSeconds));
 
 		$consumerHandler = new ConsumerHandler(
 			$stopConsumerSleepSeconds,
@@ -195,20 +196,20 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 
 		$dequeuer = $this->getDequeuerMock();
 		$dequeuer
-			->expects($this->never())
-			->method($this->anything());
+			->expects(self::never())
+			->method(Assert::anything());
 
 		$logger = $this->getLoggerMock();
 		$logger
-			->expects($this->never())
-			->method($this->anything());
+			->expects(self::never())
+			->method(Assert::anything());
 
 		$entityManager = $this->getOpenEntityManagerMock();
 
 		$sleeper = $this->getSleeperMock();
 		$sleeper
-			->expects($this->never())
-			->method($this->anything());
+			->expects(self::never())
+			->method(Assert::anything());
 
 		return new ConsumerHandler(
 			$stopConsumerSleepSeconds,
@@ -232,8 +233,8 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 
 		$sleeper = $this->getSleeperMock();
 		$sleeper
-			->expects($this->never())
-			->method($this->anything());
+			->expects(self::never())
+			->method(Assert::anything());
 
 		$consumerHandler = new ConsumerHandler(
 			$stopConsumerSleepSeconds,
@@ -244,7 +245,7 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 			$sleeper
 		);
 
-		$this->assertSame(ConsumerInterface::MSG_REJECT_REQUEUE, $consumerHandler->processMessage(
+		Assert::assertSame(ConsumerInterface::MSG_REJECT_REQUEUE, $consumerHandler->processMessage(
 			function (): void {
 				throw new \Exception('Test');
 			}
@@ -257,23 +258,23 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 
 		$dequeuer = $this->getDequeuerMock();
 		$dequeuer
-			->expects($this->never())
-			->method($this->anything());
+			->expects(self::never())
+			->method(Assert::anything());
 
 		$logger = $this->getLoggerMock();
 		$logger
-			->expects($this->never())
-			->method($this->anything());
+			->expects(self::never())
+			->method(Assert::anything());
 
 		$entityManager = $this->getOpenEntityManagerMock();
 		$entityManager
-			->expects($this->once())
+			->expects(self::once())
 			->method('clear');
 
 		$sleeper = $this->getSleeperMock();
 		$sleeper
-			->expects($this->never())
-			->method($this->anything());
+			->expects(self::never())
+			->method(Assert::anything());
 
 		$consumerHandler = new ConsumerHandler(
 			$stopConsumerSleepSeconds,
@@ -297,23 +298,23 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 
 		$dequeuer = $this->getDequeuerMock();
 		$dequeuer
-			->expects($this->never())
-			->method($this->anything());
+			->expects(self::never())
+			->method(Assert::anything());
 
 		$logger = $this->getLoggerMock();
 		$logger
-			->expects($this->never())
-			->method($this->anything());
+			->expects(self::never())
+			->method(Assert::anything());
 
 		$entityManager = $this->getOpenEntityManagerMock();
 		$entityManager
-			->expects($this->never())
+			->expects(self::never())
 			->method('clear');
 
 		$sleeper = $this->getSleeperMock();
 		$sleeper
-			->expects($this->never())
-			->method($this->anything());
+			->expects(self::never())
+			->method(Assert::anything());
 
 		$consumerHandler = new ConsumerHandler(
 			$stopConsumerSleepSeconds,
@@ -370,9 +371,9 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 	{
 		$entityManager = $this->getEntityManagerMock();
 		$entityManager
-			->expects($this->any())
+			->expects(self::any())
 			->method('isOpen')
-			->will($this->returnValue(true));
+			->will(self::returnValue(true));
 
 		return $entityManager;
 	}

--- a/tests/ConsumerHandler/ConsumerHandlerTest.php
+++ b/tests/ConsumerHandler/ConsumerHandlerTest.php
@@ -55,14 +55,18 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 
 		$stopConsumerSleepSeconds = 2;
 
-		$dequeuer = $this->getDequeuerMock();
+		$dequeuer = $this->createMock(DequeuerInterface::class);
 		$dequeuer
 			->expects(self::once())
 			->method('forceStopConsumer');
 
-		$entityManager = $this->getOpenEntityManagerMock();
+		$entityManager = $this->createMock(EntityManager::class);
+		$entityManager
+			->expects(self::any())
+			->method('isOpen')
+			->will(self::returnValue(true));
 
-		$logger = $this->getLoggerMock();
+		$logger = $this->createMock(LoggerInterface::class);
 		$logger
 			->expects(self::once())
 			->method('error')
@@ -77,7 +81,7 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 			->method('log')
 			->with(LogLevel::WARNING, Assert::stringContains('uncaught exception'));
 
-		$sleeper = $this->getSleeperMock();
+		$sleeper = $this->createMock(Sleeper::class);
 		$sleeper
 			->expects(self::once())
 			->method('sleep')
@@ -116,24 +120,24 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 	{
 		$stopConsumerSleepSeconds = 2;
 
-		$dequeuer = $this->getDequeuerMock();
+		$dequeuer = $this->createMock(DequeuerInterface::class);
 		$dequeuer
 			->expects(self::once())
 			->method('forceStopConsumer');
 
-		$logger = $this->getLoggerMock();
+		$logger = $this->createMock(LoggerInterface::class);
 		$logger
 			->expects(self::once())
 			->method('log')
 			->with(LogLevel::WARNING, Assert::stringContains('EntityManager was closed'));
 
-		$entityManager = $this->getEntityManagerMock();
+		$entityManager = $this->createMock(EntityManager::class);
 		$entityManager
 			->expects(self::any())
 			->method('isOpen')
 			->will(self::returnValue(false));
 
-		$sleeper = $this->getSleeperMock();
+		$sleeper = $this->createMock(Sleeper::class);
 		$sleeper
 			->expects(self::once())
 			->method('sleep')
@@ -157,12 +161,12 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 	{
 		$stopConsumerSleepSeconds = 2;
 
-		$dequeuer = $this->getDequeuerMock();
+		$dequeuer = $this->createMock(DequeuerInterface::class);
 		$dequeuer
 			->expects(self::once())
 			->method('forceStopConsumer');
 
-		$logger = $this->getLoggerMock();
+		$logger = $this->createMock(LoggerInterface::class);
 		$logger
 			->expects(self::once())
 			->method('log')
@@ -171,13 +175,13 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 			->expects(self::any())
 			->method('error');
 
-		$entityManager = $this->getEntityManagerMock();
+		$entityManager = $this->createMock(EntityManager::class);
 		$entityManager
 			->expects(self::any())
 			->method('isOpen')
 			->will(self::returnValue(false));
 
-		$sleeper = $this->getSleeperMock();
+		$sleeper = $this->createMock(Sleeper::class);
 		$sleeper
 			->expects(self::once())
 			->method('sleep')
@@ -201,19 +205,23 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 	{
 		$stopConsumerSleepSeconds = 2;
 
-		$dequeuer = $this->getDequeuerMock();
+		$dequeuer = $this->createMock(DequeuerInterface::class);
 		$dequeuer
 			->expects(self::never())
 			->method(Assert::anything());
 
-		$logger = $this->getLoggerMock();
+		$logger = $this->createMock(LoggerInterface::class);
 		$logger
 			->expects(self::never())
 			->method(Assert::anything());
 
-		$entityManager = $this->getOpenEntityManagerMock();
+		$entityManager = $this->createMock(EntityManager::class);
+		$entityManager
+			->expects(self::any())
+			->method('isOpen')
+			->will(self::returnValue(true));
 
-		$sleeper = $this->getSleeperMock();
+		$sleeper = $this->createMock(Sleeper::class);
 		$sleeper
 			->expects(self::never())
 			->method(Assert::anything());
@@ -232,13 +240,17 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 	{
 		$stopConsumerSleepSeconds = 0;
 
-		$dequeuer = $this->getDequeuerMock();
+		$dequeuer = $this->createMock(DequeuerInterface::class);
 
-		$entityManager = $this->getOpenEntityManagerMock();
+		$entityManager = $this->createMock(EntityManager::class);
+		$entityManager
+			->expects(self::any())
+			->method('isOpen')
+			->will(self::returnValue(true));
 
-		$logger = $this->getLoggerMock();
+		$logger = $this->createMock(LoggerInterface::class);
 
-		$sleeper = $this->getSleeperMock();
+		$sleeper = $this->createMock(Sleeper::class);
 		$sleeper
 			->expects(self::never())
 			->method(Assert::anything());
@@ -263,22 +275,26 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 	{
 		$stopConsumerSleepSeconds = 2;
 
-		$dequeuer = $this->getDequeuerMock();
+		$dequeuer = $this->createMock(DequeuerInterface::class);
 		$dequeuer
 			->expects(self::never())
 			->method(Assert::anything());
 
-		$logger = $this->getLoggerMock();
+		$logger = $this->createMock(LoggerInterface::class);
 		$logger
 			->expects(self::never())
 			->method(Assert::anything());
 
-		$entityManager = $this->getOpenEntityManagerMock();
+		$entityManager = $this->createMock(EntityManager::class);
+		$entityManager
+			->expects(self::any())
+			->method('isOpen')
+			->will(self::returnValue(true));
 		$entityManager
 			->expects(self::once())
 			->method('clear');
 
-		$sleeper = $this->getSleeperMock();
+		$sleeper = $this->createMock(Sleeper::class);
 		$sleeper
 			->expects(self::never())
 			->method(Assert::anything());
@@ -303,22 +319,26 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 	{
 		$stopConsumerSleepSeconds = 2;
 
-		$dequeuer = $this->getDequeuerMock();
+		$dequeuer = $this->createMock(DequeuerInterface::class);
 		$dequeuer
 			->expects(self::never())
 			->method(Assert::anything());
 
-		$logger = $this->getLoggerMock();
+		$logger = $this->createMock(LoggerInterface::class);
 		$logger
 			->expects(self::never())
 			->method(Assert::anything());
 
-		$entityManager = $this->getOpenEntityManagerMock();
+		$entityManager = $this->createMock(EntityManager::class);
+		$entityManager
+			->expects(self::any())
+			->method('isOpen')
+			->will(self::returnValue(true));
 		$entityManager
 			->expects(self::never())
 			->method('clear');
 
-		$sleeper = $this->getSleeperMock();
+		$sleeper = $this->createMock(Sleeper::class);
 		$sleeper
 			->expects(self::never())
 			->method(Assert::anything());
@@ -337,52 +357,6 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 				return ConsumerInterface::MSG_ACK;
 			}
 		);
-	}
-
-	/**
-	 * @return \OldSound\RabbitMqBundle\RabbitMq\DequeuerInterface|\PHPUnit\Framework\MockObject\MockObject
-	 */
-	private function getDequeuerMock()
-	{
-		return $this->createMock(DequeuerInterface::class);
-	}
-
-	/**
-	 * @return \Psr\Log\LoggerInterface|\PHPUnit\Framework\MockObject\MockObject
-	 */
-	private function getLoggerMock()
-	{
-		return $this->createMock(LoggerInterface::class);
-	}
-
-	/**
-	 * @return \VasekPurchart\RabbitMqConsumerHandlerBundle\Sleeper\Sleeper|\PHPUnit\Framework\MockObject\MockObject
-	 */
-	private function getSleeperMock()
-	{
-		return $this->createMock(Sleeper::class);
-	}
-
-	/**
-	 * @return \Doctrine\ORM\EntityManager|\PHPUnit\Framework\MockObject\MockObject
-	 */
-	private function getEntityManagerMock()
-	{
-		return $this->createMock(EntityManager::class);
-	}
-
-	/**
-	 * @return \Doctrine\ORM\EntityManager|\PHPUnit\Framework\MockObject\MockObject
-	 */
-	private function getOpenEntityManagerMock()
-	{
-		$entityManager = $this->getEntityManagerMock();
-		$entityManager
-			->expects(self::any())
-			->method('isOpen')
-			->will(self::returnValue(true));
-
-		return $entityManager;
 	}
 
 }

--- a/tests/ConsumerHandler/ConsumerHandlerTest.php
+++ b/tests/ConsumerHandler/ConsumerHandlerTest.php
@@ -21,16 +21,16 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function resultCodeDataProvider(): Generator
 	{
-		yield [
+		yield 'MSG_ACK' => [
 			'code' => ConsumerInterface::MSG_ACK,
 		];
-		yield [
+		yield 'MSG_REJECT' => [
 			'code' => ConsumerInterface::MSG_REJECT,
 		];
-		yield [
+		yield 'MSG_REJECT_REQUEUE' => [
 			'code' => ConsumerInterface::MSG_REJECT_REQUEUE,
 		];
-		yield [
+		yield 'MSG_SINGLE_NACK_REQUEUE' => [
 			'code' => ConsumerInterface::MSG_SINGLE_NACK_REQUEUE,
 		];
 	}

--- a/tests/ConsumerHandler/ConsumerHandlerTest.php
+++ b/tests/ConsumerHandler/ConsumerHandlerTest.php
@@ -22,16 +22,16 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 	public function resultCodeDataProvider(): Generator
 	{
 		yield [
-			ConsumerInterface::MSG_ACK,
+			'code' => ConsumerInterface::MSG_ACK,
 		];
 		yield [
-			ConsumerInterface::MSG_REJECT,
+			'code' => ConsumerInterface::MSG_REJECT,
 		];
 		yield [
-			ConsumerInterface::MSG_REJECT_REQUEUE,
+			'code' => ConsumerInterface::MSG_REJECT_REQUEUE,
 		];
 		yield [
-			ConsumerInterface::MSG_SINGLE_NACK_REQUEUE,
+			'code' => ConsumerInterface::MSG_SINGLE_NACK_REQUEUE,
 		];
 	}
 

--- a/tests/ConsumerHandler/ConsumerHandlerTest.php
+++ b/tests/ConsumerHandler/ConsumerHandlerTest.php
@@ -21,10 +21,18 @@ class ConsumerHandlerTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function resultCodeDataProvider(): Generator
 	{
-		yield [ConsumerInterface::MSG_ACK];
-		yield [ConsumerInterface::MSG_REJECT];
-		yield [ConsumerInterface::MSG_REJECT_REQUEUE];
-		yield [ConsumerInterface::MSG_SINGLE_NACK_REQUEUE];
+		yield [
+			ConsumerInterface::MSG_ACK,
+		];
+		yield [
+			ConsumerInterface::MSG_REJECT,
+		];
+		yield [
+			ConsumerInterface::MSG_REJECT_REQUEUE,
+		];
+		yield [
+			ConsumerInterface::MSG_SINGLE_NACK_REQUEUE,
+		];
 	}
 
 	/**

--- a/tests/DependencyInjection/ConsumerHandlerCompilerPassTest.php
+++ b/tests/DependencyInjection/ConsumerHandlerCompilerPassTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace VasekPurchart\RabbitMqConsumerHandlerBundle\DependencyInjection;
 
 use OldSound\RabbitMqBundle\RabbitMq\Consumer;
+use PHPUnit\Framework\Assert;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Parameter;
@@ -46,8 +47,8 @@ class ConsumerHandlerCompilerPassTest extends \Matthias\SymfonyDependencyInjecti
 		$dequeuerArgument = $this->container->findDefinition(
 			'vasek_purchart.rabbit_mq_consumer_handler.consumer_handler.id.my_consumer_name'
 		)->getArgument('$dequeuer');
-		$this->assertInstanceOf(Reference::class, $dequeuerArgument);
-		$this->assertSame(
+		Assert::assertInstanceOf(Reference::class, $dequeuerArgument);
+		Assert::assertSame(
 			$consumerServiceId,
 			$dequeuerArgument->__toString()
 		);
@@ -91,8 +92,8 @@ class ConsumerHandlerCompilerPassTest extends \Matthias\SymfonyDependencyInjecti
 		$stopConsumerSleepSeconds = $this->container->findDefinition(
 			'vasek_purchart.rabbit_mq_consumer_handler.consumer_handler.id.default_configuration'
 		)->getArgument('$stopConsumerSleepSeconds');
-		$this->assertInstanceOf(Parameter::class, $stopConsumerSleepSeconds);
-		$this->assertSame(
+		Assert::assertInstanceOf(Parameter::class, $stopConsumerSleepSeconds);
+		Assert::assertSame(
 			RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_STOP_CONSUMER_SLEEP_SECONDS,
 			$stopConsumerSleepSeconds->__toString()
 		);
@@ -103,7 +104,7 @@ class ConsumerHandlerCompilerPassTest extends \Matthias\SymfonyDependencyInjecti
 		$stopConsumerSleepSeconds = $this->container->findDefinition(
 			'vasek_purchart.rabbit_mq_consumer_handler.consumer_handler.id.custom_configuration'
 		)->getArgument('$stopConsumerSleepSeconds');
-		$this->assertSame(
+		Assert::assertSame(
 			3,
 			$stopConsumerSleepSeconds
 		);
@@ -115,8 +116,8 @@ class ConsumerHandlerCompilerPassTest extends \Matthias\SymfonyDependencyInjecti
 		$logger = $this->container->findDefinition(
 			'vasek_purchart.rabbit_mq_consumer_handler.consumer_handler.id.default_configuration'
 		)->getArgument('$logger');
-		$this->assertInstanceOf(Reference::class, $logger);
-		$this->assertSame(
+		Assert::assertInstanceOf(Reference::class, $logger);
+		Assert::assertSame(
 			RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_LOGGER,
 			$logger->__toString()
 		);
@@ -127,8 +128,8 @@ class ConsumerHandlerCompilerPassTest extends \Matthias\SymfonyDependencyInjecti
 		$logger = $this->container->findDefinition(
 			'vasek_purchart.rabbit_mq_consumer_handler.consumer_handler.id.custom_configuration'
 		)->getArgument('$logger');
-		$this->assertInstanceOf(Reference::class, $logger);
-		$this->assertSame(
+		Assert::assertInstanceOf(Reference::class, $logger);
+		Assert::assertSame(
 			'my_custom_logger',
 			$logger->__toString()
 		);
@@ -140,8 +141,8 @@ class ConsumerHandlerCompilerPassTest extends \Matthias\SymfonyDependencyInjecti
 		$entityManager = $this->container->findDefinition(
 			'vasek_purchart.rabbit_mq_consumer_handler.consumer_handler.id.default_configuration'
 		)->getArgument('$entityManager');
-		$this->assertInstanceOf(Reference::class, $entityManager);
-		$this->assertSame(
+		Assert::assertInstanceOf(Reference::class, $entityManager);
+		Assert::assertSame(
 			RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_ENTITY_MANAGER,
 			$entityManager->__toString()
 		);
@@ -152,8 +153,8 @@ class ConsumerHandlerCompilerPassTest extends \Matthias\SymfonyDependencyInjecti
 		$entityManager = $this->container->findDefinition(
 			'vasek_purchart.rabbit_mq_consumer_handler.consumer_handler.id.custom_configuration'
 		)->getArgument('$entityManager');
-		$this->assertInstanceOf(Reference::class, $entityManager);
-		$this->assertSame(
+		Assert::assertInstanceOf(Reference::class, $entityManager);
+		Assert::assertSame(
 			'my_custom_entity_manager',
 			$entityManager->__toString()
 		);
@@ -165,8 +166,8 @@ class ConsumerHandlerCompilerPassTest extends \Matthias\SymfonyDependencyInjecti
 		$clearEntityManager = $this->container->findDefinition(
 			'vasek_purchart.rabbit_mq_consumer_handler.consumer_handler.id.default_configuration'
 		)->getArgument('$clearEntityManager');
-		$this->assertInstanceOf(Parameter::class, $clearEntityManager);
-		$this->assertSame(
+		Assert::assertInstanceOf(Parameter::class, $clearEntityManager);
+		Assert::assertSame(
 			RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_ENTITY_MANAGER_CLEAR,
 			$clearEntityManager->__toString()
 		);
@@ -177,7 +178,7 @@ class ConsumerHandlerCompilerPassTest extends \Matthias\SymfonyDependencyInjecti
 		$clearEntityManager = $this->container->findDefinition(
 			'vasek_purchart.rabbit_mq_consumer_handler.consumer_handler.id.custom_configuration'
 		)->getArgument('$clearEntityManager');
-		$this->assertSame(
+		Assert::assertSame(
 			false,
 			$clearEntityManager
 		);
@@ -198,10 +199,10 @@ class ConsumerHandlerCompilerPassTest extends \Matthias\SymfonyDependencyInjecti
 		try {
 			$this->compile();
 
-			$this->fail('Exception expected, should not be reached');
+			Assert::fail('Exception expected, should not be reached');
 
 		} catch (\VasekPurchart\RabbitMqConsumerHandlerBundle\DependencyInjection\UnusedConsumerConfigurationException $e) {
-			$this->assertContains('my_consumer_xxx', $e->getConsumerNames());
+			Assert::assertContains('my_consumer_xxx', $e->getConsumerNames());
 		}
 	}
 

--- a/tests/DependencyInjection/ConsumerHandlerCompilerPassTest.php
+++ b/tests/DependencyInjection/ConsumerHandlerCompilerPassTest.php
@@ -199,7 +199,7 @@ class ConsumerHandlerCompilerPassTest extends \Matthias\SymfonyDependencyInjecti
 		try {
 			$this->compile();
 
-			Assert::fail('Exception expected, should not be reached');
+			Assert::fail('Exception expected');
 
 		} catch (\VasekPurchart\RabbitMqConsumerHandlerBundle\DependencyInjection\UnusedConsumerConfigurationException $e) {
 			Assert::assertContains('my_consumer_xxx', $e->getConsumerNames());

--- a/tests/DependencyInjection/RabbitMqConsumerHandlerExtensionTest.php
+++ b/tests/DependencyInjection/RabbitMqConsumerHandlerExtensionTest.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace VasekPurchart\RabbitMqConsumerHandlerBundle\DependencyInjection;
 
+use PHPUnit\Framework\Assert;
+
 class RabbitMqConsumerHandlerExtensionTest extends \Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase
 {
 
@@ -172,10 +174,10 @@ class RabbitMqConsumerHandlerExtensionTest extends \Matthias\SymfonyDependencyIn
 			RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_CUSTOM_CONSUMER_CONFIGURATIONS
 		);
 		$customConsumerConfigurations = $this->container->getParameter(RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_CUSTOM_CONSUMER_CONFIGURATIONS);
-		$this->assertArrayHasKey('my_consumer', $customConsumerConfigurations);
+		Assert::assertArrayHasKey('my_consumer', $customConsumerConfigurations);
 
-		$this->assertArrayHasKey('stop_consumer_sleep_seconds', $customConsumerConfigurations['my_consumer']);
-		$this->assertSame(3, $customConsumerConfigurations['my_consumer']['stop_consumer_sleep_seconds']);
+		Assert::assertArrayHasKey('stop_consumer_sleep_seconds', $customConsumerConfigurations['my_consumer']);
+		Assert::assertSame(3, $customConsumerConfigurations['my_consumer']['stop_consumer_sleep_seconds']);
 
 		$this->compile();
 	}

--- a/tests/DependencyInjection/RabbitMqConsumerHandlerExtensionTest.php
+++ b/tests/DependencyInjection/RabbitMqConsumerHandlerExtensionTest.php
@@ -23,36 +23,6 @@ class RabbitMqConsumerHandlerExtensionTest extends \Matthias\SymfonyDependencyIn
 	/**
 	 * @return mixed[][]|\Generator
 	 */
-	public function defaultConfigurationValuesDataProvider(): Generator
-	{
-		yield 'stop_consumer_sleep_seconds' => [
-			'parameterName' => RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_STOP_CONSUMER_SLEEP_SECONDS,
-			'parameterValue' => 1,
-		];
-		yield 'entity_manager.clear' => [
-			'parameterName' => RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_ENTITY_MANAGER_CLEAR,
-			'parameterValue' => true,
-		];
-	}
-
-	/**
-	 * @dataProvider defaultConfigurationValuesDataProvider
-	 *
-	 * @param string $parameterName
-	 * @param mixed $parameterValue
-	 */
-	public function testDefaultConfigurationValues(string $parameterName, $parameterValue): void
-	{
-		$this->load();
-
-		$this->assertContainerBuilderHasParameter($parameterName, $parameterValue);
-
-		$this->compile();
-	}
-
-	/**
-	 * @return mixed[][]|\Generator
-	 */
 	public function defaultConfigurationServiceAliasesDataProvider(): Generator
 	{
 		yield 'logger' => [
@@ -80,29 +50,68 @@ class RabbitMqConsumerHandlerExtensionTest extends \Matthias\SymfonyDependencyIn
 		$this->compile();
 	}
 
-	public function testConfigureStopConsumerSleepSeconds(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function configureContainerParameterDataProvider(): Generator
 	{
-		$this->load([
-			'stop_consumer_sleep_seconds' => 2,
-		]);
+		yield 'default stop_consumer_sleep_seconds value' => [
+			'configuration' => [],
+			'parameterName' => RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_STOP_CONSUMER_SLEEP_SECONDS,
+			'expectedParameterValue' => 1,
+		];
 
-		$this->assertContainerBuilderHasParameter(
-			RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_STOP_CONSUMER_SLEEP_SECONDS,
-			2
-		);
+		yield 'default entity_manager.clear value' => [
+			'configuration' => [],
+			'parameterName' => RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_ENTITY_MANAGER_CLEAR,
+			'expectedParameterValue' => true,
+		];
 
-		$this->compile();
+		yield 'set stop_consumer_sleep_seconds' => [
+			'configuration' => [
+				'stop_consumer_sleep_seconds' => 2,
+			],
+			'parameterName' => RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_STOP_CONSUMER_SLEEP_SECONDS,
+			'expectedParameterValue' => 2,
+		];
+
+		yield 'disable stop_consumer_sleep_seconds' => [
+			'configuration' => [
+				'stop_consumer_sleep_seconds' => false,
+			],
+			'parameterName' => RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_STOP_CONSUMER_SLEEP_SECONDS,
+			'expectedParameterValue' => 0,
+		];
+
+		yield 'disable entity_manager.clear' => [
+			'configuration' => [
+				'entity_manager' => [
+					'clear_em_before_message' => false,
+				],
+			],
+			'parameterName' => RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_ENTITY_MANAGER_CLEAR,
+			'expectedParameterValue' => false,
+		];
 	}
 
-	public function testDisableStopConsumerSleepSeconds(): void
+	/**
+	 * @dataProvider configureContainerParameterDataProvider
+	 *
+	 * @param mixed[][] $configuration
+	 * @param string $parameterName
+	 * @param mixed $expectedParameterValue
+	 */
+	public function testConfigureContainerParameter(
+		array $configuration,
+		string $parameterName,
+		$expectedParameterValue
+	): void
 	{
-		$this->load([
-			'stop_consumer_sleep_seconds' => false,
-		]);
+		$this->load($configuration);
 
 		$this->assertContainerBuilderHasParameter(
-			RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_STOP_CONSUMER_SLEEP_SECONDS,
-			0
+			$parameterName,
+			$expectedParameterValue
 		);
 
 		$this->compile();
@@ -135,22 +144,6 @@ class RabbitMqConsumerHandlerExtensionTest extends \Matthias\SymfonyDependencyIn
 		$this->assertContainerBuilderHasAlias(
 			RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_ENTITY_MANAGER,
 			'my_entity_manager'
-		);
-
-		$this->compile();
-	}
-
-	public function testDisableEntityManagerClear(): void
-	{
-		$this->load([
-			'entity_manager' => [
-				'clear_em_before_message' => false,
-			],
-		]);
-
-		$this->assertContainerBuilderHasParameter(
-			RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_ENTITY_MANAGER_CLEAR,
-			false
 		);
 
 		$this->compile();

--- a/tests/DependencyInjection/RabbitMqConsumerHandlerExtensionTest.php
+++ b/tests/DependencyInjection/RabbitMqConsumerHandlerExtensionTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace VasekPurchart\RabbitMqConsumerHandlerBundle\DependencyInjection;
 
+use Generator;
 use PHPUnit\Framework\Assert;
 
 class RabbitMqConsumerHandlerExtensionTest extends \Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase
@@ -20,19 +21,17 @@ class RabbitMqConsumerHandlerExtensionTest extends \Matthias\SymfonyDependencyIn
 	}
 
 	/**
-	 * @return mixed[][]
+	 * @return mixed[][]|\Generator
 	 */
-	public function defaultConfigurationValuesDataProvider(): array
+	public function defaultConfigurationValuesDataProvider(): Generator
 	{
-		return [
-			[
-				RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_STOP_CONSUMER_SLEEP_SECONDS,
-				1,
-			],
-			[
-				RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_ENTITY_MANAGER_CLEAR,
-				true,
-			],
+		yield [
+			RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_STOP_CONSUMER_SLEEP_SECONDS,
+			1,
+		];
+		yield [
+			RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_ENTITY_MANAGER_CLEAR,
+			true,
 		];
 	}
 
@@ -52,19 +51,17 @@ class RabbitMqConsumerHandlerExtensionTest extends \Matthias\SymfonyDependencyIn
 	}
 
 	/**
-	 * @return mixed[][]
+	 * @return mixed[][]|\Generator
 	 */
-	public function defaultConfigurationServiceAliasesDataProvider(): array
+	public function defaultConfigurationServiceAliasesDataProvider(): Generator
 	{
-		return [
-			[
-				RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_LOGGER,
-				'logger',
-			],
-			[
-				RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_ENTITY_MANAGER,
-				'doctrine.orm.default_entity_manager',
-			],
+		yield [
+			RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_LOGGER,
+			'logger',
+		];
+		yield [
+			RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_ENTITY_MANAGER,
+			'doctrine.orm.default_entity_manager',
 		];
 	}
 

--- a/tests/DependencyInjection/RabbitMqConsumerHandlerExtensionTest.php
+++ b/tests/DependencyInjection/RabbitMqConsumerHandlerExtensionTest.php
@@ -22,7 +22,7 @@ class RabbitMqConsumerHandlerExtensionTest extends \Matthias\SymfonyDependencyIn
 	/**
 	 * @return mixed[][]
 	 */
-	public function defaultConfigurationValuesProvider(): array
+	public function defaultConfigurationValuesDataProvider(): array
 	{
 		return [
 			[
@@ -37,7 +37,7 @@ class RabbitMqConsumerHandlerExtensionTest extends \Matthias\SymfonyDependencyIn
 	}
 
 	/**
-	 * @dataProvider defaultConfigurationValuesProvider
+	 * @dataProvider defaultConfigurationValuesDataProvider
 	 *
 	 * @param string $parameterName
 	 * @param mixed $parameterValue
@@ -54,7 +54,7 @@ class RabbitMqConsumerHandlerExtensionTest extends \Matthias\SymfonyDependencyIn
 	/**
 	 * @return mixed[][]
 	 */
-	public function defaultConfigurationServiceAliasesProvider(): array
+	public function defaultConfigurationServiceAliasesDataProvider(): array
 	{
 		return [
 			[
@@ -69,7 +69,7 @@ class RabbitMqConsumerHandlerExtensionTest extends \Matthias\SymfonyDependencyIn
 	}
 
 	/**
-	 * @dataProvider defaultConfigurationServiceAliasesProvider
+	 * @dataProvider defaultConfigurationServiceAliasesDataProvider
 	 *
 	 * @param string $aliasName
 	 * @param string $targetServiceId

--- a/tests/DependencyInjection/RabbitMqConsumerHandlerExtensionTest.php
+++ b/tests/DependencyInjection/RabbitMqConsumerHandlerExtensionTest.php
@@ -25,11 +25,11 @@ class RabbitMqConsumerHandlerExtensionTest extends \Matthias\SymfonyDependencyIn
 	 */
 	public function defaultConfigurationValuesDataProvider(): Generator
 	{
-		yield [
+		yield 'stop_consumer_sleep_seconds' => [
 			'parameterName' => RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_STOP_CONSUMER_SLEEP_SECONDS,
 			'parameterValue' => 1,
 		];
-		yield [
+		yield 'entity_manager.clear' => [
 			'parameterName' => RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_ENTITY_MANAGER_CLEAR,
 			'parameterValue' => true,
 		];
@@ -55,11 +55,11 @@ class RabbitMqConsumerHandlerExtensionTest extends \Matthias\SymfonyDependencyIn
 	 */
 	public function defaultConfigurationServiceAliasesDataProvider(): Generator
 	{
-		yield [
+		yield 'logger' => [
 			'aliasName' => RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_LOGGER,
 			'targetServiceId' => 'logger',
 		];
-		yield [
+		yield 'entity_manager' => [
 			'aliasName' => RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_ENTITY_MANAGER,
 			'targetServiceId' => 'doctrine.orm.default_entity_manager',
 		];

--- a/tests/DependencyInjection/RabbitMqConsumerHandlerExtensionTest.php
+++ b/tests/DependencyInjection/RabbitMqConsumerHandlerExtensionTest.php
@@ -23,36 +23,6 @@ class RabbitMqConsumerHandlerExtensionTest extends \Matthias\SymfonyDependencyIn
 	/**
 	 * @return mixed[][]|\Generator
 	 */
-	public function defaultConfigurationServiceAliasesDataProvider(): Generator
-	{
-		yield 'logger' => [
-			'aliasName' => RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_LOGGER,
-			'targetServiceId' => 'logger',
-		];
-		yield 'entity_manager' => [
-			'aliasName' => RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_ENTITY_MANAGER,
-			'targetServiceId' => 'doctrine.orm.default_entity_manager',
-		];
-	}
-
-	/**
-	 * @dataProvider defaultConfigurationServiceAliasesDataProvider
-	 *
-	 * @param string $aliasName
-	 * @param string $targetServiceId
-	 */
-	public function testDefaultConfigurationServices(string $aliasName, string $targetServiceId): void
-	{
-		$this->load();
-
-		$this->assertContainerBuilderHasAlias($aliasName, $targetServiceId);
-
-		$this->compile();
-	}
-
-	/**
-	 * @return mixed[][]|\Generator
-	 */
 	public function configureContainerParameterDataProvider(): Generator
 	{
 		yield 'default stop_consumer_sleep_seconds value' => [
@@ -117,33 +87,62 @@ class RabbitMqConsumerHandlerExtensionTest extends \Matthias\SymfonyDependencyIn
 		$this->compile();
 	}
 
-	public function testConfigureCustomLoggerInstance(): void
+	/**
+	 * @return mixed[][]|\Generator
+	 */
+	public function configureContainerServiceAliasDataProvider(): Generator
 	{
-		$this->load([
-			'logger' => [
-				'service_id' => 'my_logger',
+		yield 'default logger' => [
+			'configuration' => [],
+			'aliasId' => RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_LOGGER,
+			'expectedServiceId' => 'logger',
+		];
+
+		yield 'default entity manager' => [
+			'configuration' => [],
+			'aliasId' => RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_ENTITY_MANAGER,
+			'expectedServiceId' => 'doctrine.orm.default_entity_manager',
+		];
+
+		yield 'configure custom logger instance' => [
+			'configuration' => [
+				'logger' => [
+					'service_id' => 'my_logger',
+				],
 			],
-		]);
+			'aliasId' => RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_LOGGER,
+			'expectedServiceId' => 'my_logger',
+		];
 
-		$this->assertContainerBuilderHasAlias(
-			RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_LOGGER,
-			'my_logger'
-		);
-
-		$this->compile();
+		yield 'configure custom entity manager instance' => [
+			'configuration' => [
+				'entity_manager' => [
+					'service_id' => 'my_entity_manager',
+				],
+			],
+			'aliasId' => RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_ENTITY_MANAGER,
+			'expectedServiceId' => 'my_entity_manager',
+		];
 	}
 
-	public function testConfigureCustomEntityManagerInstance(): void
+	/**
+	 * @dataProvider configureContainerServiceAliasDataProvider
+	 *
+	 * @param mixed[][] $configuration
+	 * @param string $aliasId
+	 * @param string $expectedServiceId
+	 */
+	public function testConfigureContainerService(
+		array $configuration,
+		string $aliasId,
+		string $expectedServiceId
+	): void
 	{
-		$this->load([
-			'entity_manager' => [
-				'service_id' => 'my_entity_manager',
-			],
-		]);
+		$this->load($configuration);
 
 		$this->assertContainerBuilderHasAlias(
-			RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_ENTITY_MANAGER,
-			'my_entity_manager'
+			$aliasId,
+			$expectedServiceId
 		);
 
 		$this->compile();

--- a/tests/DependencyInjection/RabbitMqConsumerHandlerExtensionTest.php
+++ b/tests/DependencyInjection/RabbitMqConsumerHandlerExtensionTest.php
@@ -26,12 +26,12 @@ class RabbitMqConsumerHandlerExtensionTest extends \Matthias\SymfonyDependencyIn
 	public function defaultConfigurationValuesDataProvider(): Generator
 	{
 		yield [
-			RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_STOP_CONSUMER_SLEEP_SECONDS,
-			1,
+			'parameterName' => RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_STOP_CONSUMER_SLEEP_SECONDS,
+			'parameterValue' => 1,
 		];
 		yield [
-			RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_ENTITY_MANAGER_CLEAR,
-			true,
+			'parameterName' => RabbitMqConsumerHandlerExtension::CONTAINER_PARAMETER_ENTITY_MANAGER_CLEAR,
+			'parameterValue' => true,
 		];
 	}
 
@@ -56,12 +56,12 @@ class RabbitMqConsumerHandlerExtensionTest extends \Matthias\SymfonyDependencyIn
 	public function defaultConfigurationServiceAliasesDataProvider(): Generator
 	{
 		yield [
-			RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_LOGGER,
-			'logger',
+			'aliasName' => RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_LOGGER,
+			'targetServiceId' => 'logger',
 		];
 		yield [
-			RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_ENTITY_MANAGER,
-			'doctrine.orm.default_entity_manager',
+			'aliasName' => RabbitMqConsumerHandlerExtension::CONTAINER_SERVICE_ENTITY_MANAGER,
+			'targetServiceId' => 'doctrine.orm.default_entity_manager',
 		];
 	}
 


### PR DESCRIPTION
- [x] stop calling static methods in tests as non-static
- [x] use assertSame() where assertEquals() is not explicitly needed
- [x] use assertCount() after assertContains() for array comparison
- [x] add missing Assert::fail() in try+catch blocks when expecting exceptions
- [x] unify Assert::fail() message
- [x] replace Consistence\TestCase::ok() with expectNotToPerformAssertions()
- [x] use try+catch+fail when expecting exceptions with properties
- [x] rename data providers to singular where applicable
- [x] use DataProvider suffix for data providers
- [x] change data provider return type from array to Generator
- [x] declare data provider values on separate lines
- [x] isolate data provider cases using Closures
- [x] name data provider values
- [x] name data provider cases
- [x] extract multiple cases from test methods to data providers
- [x] remove unnecessary private methods for creating mocks